### PR TITLE
Enhance tab switching to support multiple windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quick-tab-switcher",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quick-tab-switcher",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@types/webextension-polyfill": "^0.10.7",

--- a/src/OptionsInterface.ts
+++ b/src/OptionsInterface.ts
@@ -24,6 +24,7 @@ export interface OptionsInterface {
     autofocusSearch: boolean;
     sortMode: SortModes;
     filterFirefoxView: boolean;
+    skipFirst: boolean;
 }
 
 export class Options implements OptionsInterface {
@@ -36,6 +37,7 @@ export class Options implements OptionsInterface {
     autofocusSearch: boolean;
     sortMode: SortModes;
     filterFirefoxView: boolean;
+    skipFirst: boolean;
 
     constructor(obj: Partial<OptionsInterface>) {
         this.shortcut = obj.shortcut ?? "Ctrl+Shift+B";
@@ -47,5 +49,6 @@ export class Options implements OptionsInterface {
         this.autofocusSearch = obj.autofocusSearch ?? false;
         this.sortMode = obj.sortMode ?? SortModes.DEFAULT;
         this.filterFirefoxView = obj.filterFirefoxView ?? true;
+        this.skipFirst = obj.skipFirst ?? false;
     }
 }

--- a/src/OptionsInterface.ts
+++ b/src/OptionsInterface.ts
@@ -17,6 +17,7 @@ export enum SortModes {
 export interface OptionsInterface {
     shortcut: string;
     searchMode: SearchModes;
+    searchCurrentWindowOnly: boolean;
     caseSensitivity: boolean;
     theme: Themes;
     showDead: boolean;
@@ -30,6 +31,7 @@ export interface OptionsInterface {
 export class Options implements OptionsInterface {
     shortcut: string;
     searchMode: SearchModes;
+    searchCurrentWindowOnly: boolean;
     caseSensitivity: boolean;
     theme: Themes;
     showDead: boolean;
@@ -42,6 +44,7 @@ export class Options implements OptionsInterface {
     constructor(obj: Partial<OptionsInterface>) {
         this.shortcut = obj.shortcut ?? "Ctrl+Shift+B";
         this.searchMode = obj.searchMode ?? SearchModes.STRING;
+        this.searchCurrentWindowOnly = obj.searchCurrentWindowOnly ?? true;
         this.caseSensitivity = obj.caseSensitivity ?? false;
         this.theme = obj.theme ?? Themes.SYSTEM;
         this.showDead = obj.showDead ?? false;

--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -4,6 +4,7 @@ import { Options, SearchModes, SortModes, Themes } from "../OptionsInterface";
 
 const shortcut = document.querySelector("#shortcut") as HTMLInputElement;
 const searchMode = document.querySelector("#searchMode") as HTMLSelectElement;
+const searchCurrentWindowOnly = document.querySelector("#searchCurrentWindowOnly") as HTMLSelectElement;
 const caseSensitivity = document.querySelector("#caseSensitivity") as HTMLSelectElement;
 const showDead = document.querySelector("#showDead") as HTMLSelectElement;
 const maxDead = document.querySelector("#maxDead") as HTMLInputElement;
@@ -17,6 +18,7 @@ async function load() {
     const res = new Options(await browser.storage.local.get());
     shortcut.value = res.shortcut;
     searchMode.value = res.searchMode;
+    searchCurrentWindowOnly.value = res.searchCurrentWindowOnly.toString();
     caseSensitivity.value = res.caseSensitivity.toString();
     theme.value = res.theme;
     showDead.value = res.showDead.toString();
@@ -37,7 +39,8 @@ function save() {
         maxDead: Number(maxDead.value),
         autofocusSearch: autofocusSearch.value === "true",
         sortMode: sortMode.value as SortModes,
-        filterFirefoxView: filterFirefoxView.checked
+        filterFirefoxView: filterFirefoxView.checked,
+        searchCurrentWindowOnly: searchCurrentWindowOnly.value === "true"
     });
 
     browser.storage.local.set(opt);

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -24,6 +24,12 @@
               <option value="true">Case Sensitive</option>
             </select>
 
+            Search Range:
+            <select id="searchCurrentWindowOnly">
+              <option value="true">Only Current Window</option>
+              <option value="false">All Windows</option>
+            </select>
+
             Autofocus Searchbar
             <select id="autofocusSearch">
               <option value="false">Don't Autofocus Search</option>

--- a/src/popup/TabElement.ts
+++ b/src/popup/TabElement.ts
@@ -9,7 +9,8 @@ export class TabElement {
     private dead: boolean;
     private active: boolean;
     private hidden = false;
-    private selected: boolean
+    private selected: boolean;
+    private windowId: number;
 
     /**
      * A tab element in the page
@@ -20,12 +21,13 @@ export class TabElement {
      * @param dead - Whether or not the tab is recently closed (dead)
      * @param active - Whether or not the tab is currently selected
      */
-    constructor(id: string, name: string, url: string, favicon: string, dead: boolean, active: boolean) {
+    constructor(id: string, name: string, url: string, favicon: string, dead: boolean, active: boolean, windowId: number) {
         this.id = id;
         this.name = name;
         this.url = url;
         this.dead = dead;
         this.active = active;
+        this.windowId = windowId!;
 
         // selected represents if the tab is currently selected in the tab bar
         // this mirrors active at creation, but active changes with user input
@@ -60,6 +62,10 @@ export class TabElement {
         if (dead) {
             this.element.classList.add("dead");
         }
+    }
+
+    get getWindowId() {
+        return this.windowId;
     }
 
     /** Title of tab */

--- a/src/popup/TabList.ts
+++ b/src/popup/TabList.ts
@@ -198,8 +198,10 @@ export class TabList {
             // restore session if tab is dead
             browser.sessions.restore(active.getID);
         } else {
-            // switch to tab if tab is alive
+            // switch to window and tab if tab is alive
             browser.tabs.update(Number(active.getID), { active: true });
+            browser.windows.update(active.getWindowId, { focused: true });
         }
     }
+
 }

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -57,7 +57,7 @@ function createTabs(info: Tabs.Tab): TabElement {
         }
     }
 
-    return new TabElement(id, name, url, favicon, dead, active);
+    return new TabElement(id, name, url, favicon, dead, active, info.windowId!);
 }
 
 /** Keyboard listener */
@@ -188,7 +188,10 @@ async function main(): Promise<void> {
     }
 
     // get tabs
-    let tabs = await browser.tabs.query({ currentWindow: true });
+    let tabs = await browser.tabs.query(
+        res.searchCurrentWindowOnly ? { currentWindow: true } : {}
+    );
+
     if (res.sortMode === SortModes.LAST_ACCESSED) {
         tabs.sort((a, b) => {
             // sort based on last accessed key for tabs

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -200,7 +200,12 @@ async function main(): Promise<void> {
             // sort based on last accessed key for tabs
             // typecast used since ts says lastAccessed could be undefined,
             // but according to the docs, this isn't true!
-            return (b.lastAccessed as number) - (a.lastAccessed as number);
+            // return (b.lastAccessed as number) - (a.lastAccessed as number);
+
+            // if lastAccessed is 0, fall back to window id
+            // ensures tabs are always in a consistent order
+            return ((b.lastAccessed as number) - (a.lastAccessed as number)) ||
+                ((b.windowId as number) - (a.windowId as number));
         });
     }
 

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -7,6 +7,8 @@ import { Options, SortModes, Themes } from "../OptionsInterface";
 /** List of tabs on the page */
 let tabList: TabList;
 
+let windowId = 0;
+
 const tabs_ele = document.querySelector("#tabs") as HTMLDivElement;
 const search = document.querySelector("#search") as HTMLInputElement;
 const overlay = document.querySelector("#overlay") as HTMLDivElement;
@@ -39,7 +41,7 @@ function createTabs(info: Tabs.Tab): TabElement {
     let dead = false;
     let active = false;
 
-    if (info.active) {
+    if (info.active && info.windowId === windowId) {
         active = true;
     }
 
@@ -181,6 +183,7 @@ function filter(): void {
 async function main(): Promise<void> {
     // get options
     const res = new Options(await browser.storage.local.get());
+    windowId = (await browser.windows.getCurrent()).id as number;
 
     // hide overlay if in focus
     if (document.hasFocus()) {


### PR DESCRIPTION
## Code Changes
- Add support for switching to tabs across windows
- Focus the target window and activate the correct tab
- Fix: missing field in `Options` class
- Update `package-lock.json`

## Tested on
- Ubuntu 22.04 LTS (x86_64)
